### PR TITLE
Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "hex",
+ "itoa",
  "serde",
  "serde_json",
  "sha2",
@@ -53,9 +54,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.3"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f8c0e2a6b902acc18214e24a6935cdaf8a8e34231913d4404dcaee659f65a1"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -248,18 +249,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.1.3"
+clap = "3.1.5"
 hex = "0.4.3"
 sha2 = "0.10.2"
 serde =  { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0" }
+serde_json = "1.0.79"
+itoa = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use std::fs::{File, OpenOptions};
 
 use std::convert;
 use std::io::{Read, Write};
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::str;
 use std::usize;
 
 const DIR: &str = "./data";
@@ -61,7 +61,7 @@ fn run() -> Result<(), BoxError> {
     }
 
     if m.is_present(WRITE) {
-        write(last, "Den".to_owned(), "Nis".to_owned(), 228)?;
+        write(last, "Den", "Nis", 228)?;
     }
 
     Ok(())
@@ -75,12 +75,12 @@ fn read(last: u64) -> Result<(), BoxError> {
         println!("blocks check started");
         for i in 2..=last {
             println!("i >> {}", i);
-            let fname = create_file_name(i);
-            let bytes = get_file_bytes(&fname)?;
-            let block = Block::deserialize(bytes).unwrap();
+            let fname = format_block_file_name(i);
+            let bytes = fs::read(&fname)?;
+            let block: Block = serde_json::from_slice(&bytes)?;
 
-            let v = get_file_bytes(&create_file_name(i - 1))?;
-            hash_vec.push(new_hash(str::from_utf8(&v)?));
+            let v = fs::read(&format_block_file_name(i - 1))?;
+            hash_vec.push(new_hash(std::str::from_utf8(&v)?));
 
             let idx = i as usize;
             if block.hash == hash_vec[idx - 2] {
@@ -92,12 +92,12 @@ fn read(last: u64) -> Result<(), BoxError> {
     };
     println!("blocks check done");
 
-    let v = get_file_bytes(&create_file_name(last))?;
-    hash_vec.push(new_hash(str::from_utf8(&v)?));
+    let v = fs::read(&format_block_file_name(last))?;
+    hash_vec.push(new_hash(std::str::from_utf8(&v)?));
 
     // from zero block
     println!("blocks check from zero started");
-    let v = get_file_bytes(&create_file_name(0))?;
+    let v = fs::read(&format_block_file_name(0))?;
     let s = String::from_utf8(v)?;
 
     let split: Vec<&str> = s.lines().collect();
@@ -120,8 +120,8 @@ fn read(last: u64) -> Result<(), BoxError> {
     Ok(())
 }
 
-fn write(last: u64, from: String, to: String, sum: u64) -> Result<(), BoxError> {
-    let new = create_file_name(last + 1);
+fn write(last: u64, from: &str, to: &str, sum: u64) -> Result<(), BoxError> {
+    let new = format_block_file_name(last + 1);
     let mut hash = "".to_owned();
 
     if Path::new(&new).exists() {
@@ -135,31 +135,23 @@ fn write(last: u64, from: String, to: String, sum: u64) -> Result<(), BoxError> 
         .open(&new)?;
 
     if last > 0 {
-        let fname = create_file_name(last);
-        let bytes = get_file_bytes(&fname)?;
-        hash = new_hash(str::from_utf8(&bytes)?)
+        let fname = format_block_file_name(last);
+        let bytes = fs::read(&fname)?;
+        hash = new_hash(std::str::from_utf8(&bytes)?)
     }
 
     let block = Block::new(from, to, sum, hash);
-    let s = block.serialize()?;
-    let _ = file.write(&s.as_bytes().to_vec())?;
+    let json = serde_json::to_vec_pretty(&block)?;
+    let _ = file.write(&json)?;
 
-    let bytes = get_file_bytes(&new)?;
+    let bytes = fs::read(&new)?;
 
-    zero_block(&new_hash(str::from_utf8(&bytes)?))?;
+    zero_block(&new_hash(std::str::from_utf8(&bytes)?))?;
     Ok(())
 }
 
-#[test]
-fn test_write() {
-    match write(2, "Den".to_owned(), "Nis".to_owned(), 228) {
-        Ok(()) => println!("done"),
-        Err(err) => exit_with_err(err),
-    }
-}
-
 fn zero_block(hash: &str) -> Result<(), BoxError> {
-    let zero = create_file_name(0);
+    let zero = format_block_file_name(0);
 
     if !Path::new(&zero).exists() {
         File::create(&zero)?;
@@ -198,33 +190,6 @@ fn last_block(dir: &str) -> Result<u64, BoxError> {
     Ok(max)
 }
 
-#[test]
-fn test_last_block() {
-    if let Ok(max) = last_block("./testdata") {
-        assert_eq!(max, 1_u64);
-    };
-}
-
-fn get_file_bytes(filename: &str) -> Result<Vec<u8>, BoxError> {
-    let mut file = fs::File::open(filename)?;
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)?;
-    Ok(data)
-}
-
-#[test]
-fn test_get_file_bytes() {
-    if let Ok(buf) = get_file_bytes("./testdata/1.json") {
-        let s = match str::from_utf8(&buf) {
-            Ok(v) => {
-                println!("{}", v);
-                assert_eq!(v, "test_get_file_bytes");
-            }
-            Err(e) => panic!("invalid utf-8 sequence: {}", e),
-        };
-    };
-}
-
 fn new_hash(msg: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(msg.as_bytes().to_vec());
@@ -232,77 +197,28 @@ fn new_hash(msg: &str) -> String {
     hex::encode(res)
 }
 
-#[test]
-fn test_new_hash() {
-    let s = new_hash("message");
-    assert_eq!(
-        s,
-        "ab530a13e45914982b79f9b7e3fba994cfd1f3fb22f71cea1afbf02b460c6d1d"
-    );
-}
+fn format_block_file_name(idx: u64) -> PathBuf {
+    let mut buf = itoa::Buffer::new();
+    let idx = buf.format(idx);
 
-fn create_file_name(idx: u64) -> String {
-    let mut fname: String = "".to_string();
-    fname.push_str(DIR);
-    fname.push('/');
-    fname.push_str(&idx.to_string());
-    fname.push_str(EXTENSION);
-    fname
-}
+    let mut path = PathBuf::with_capacity(DIR.len() + 1 + idx.len() + EXTENSION.len());
 
-#[test]
-fn test_create_file_name() {
-    let path = create_file_name(222);
-    assert_eq!(path, "./data/222.json")
+    path.push(DIR);
+    path.push(idx);
+    path.set_extension(EXTENSION);
+
+    path
 }
 
 impl Block {
-    fn new(from: String, to: String, sum: u64, hash: String) -> Self {
+    fn new(from: impl Into<String>, to: impl Into<String>, sum: u64, hash: String) -> Self {
         Block {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             sum,
             hash,
         }
     }
-
-    fn deserialize(bytes: Vec<u8>) -> Option<Self> {
-        match serde_json::from_slice::<Self>(&bytes) {
-            Ok(data) => return Some(data),
-            Err(_) => return None,
-        };
-    }
-
-    fn serialize(&self) -> Result<String, BoxError> {
-        let res = serde_json::to_string_pretty(&self)?;
-        Ok(res)
-    }
-}
-
-#[test]
-fn test_block_serialize() {
-    let block = Block::new("Den".to_owned(), "Nis".to_owned(), 228, "".to_owned());
-    if let Ok(b) = serde_json::to_string_pretty(&block) {
-        println!("{}", b)
-    };
-}
-
-#[test]
-fn test_block_deserialize() {
-    let s = r#"{
-        "from": "Den",
-        "to": "Nis",
-        "sum": 228,
-        "hash": ""
-      }"#;
-
-    if let Some(block) = Block::deserialize(s.as_bytes().to_vec()) {
-        assert_eq!(block.from, "Den");
-        assert_eq!(block.to, "Nis");
-        assert_eq!(block.sum, 228);
-        assert_eq!(block.hash, "");
-        println!("{:?}", block);
-    };
 }
 
 fn exit_with_err(err: BoxError) {
@@ -314,3 +230,6 @@ fn exit_with_err(err: BoxError) {
     }
     std::process::exit(1);
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::os::unix::prelude::OsStrExt;
+
+#[test]
+fn test_write() {
+    super::write(2, "Den", "Nis", 228).unwrap();
+}
+
+#[test]
+fn test_last_block() {
+    if let Ok(max) = super::last_block("./testdata") {
+        assert_eq!(max, 1_u64);
+    };
+}
+
+#[test]
+fn test_get_file_bytes() {
+    if let Ok(buf) = fs::read("./testdata/1.json") {
+        let s = match std::str::from_utf8(&buf) {
+            Ok(v) => {
+                println!("{}", v);
+                assert_eq!(v, "test_get_file_bytes");
+            }
+            Err(e) => panic!("invalid utf-8 sequence: {}", e),
+        };
+    };
+}
+
+#[test]
+fn test_create_file_name() {
+    let path = super::format_block_file_name(222);
+    assert_eq!(path.as_os_str().as_bytes(), b"./data/222.json")
+}
+
+#[test]
+fn test_block_serialize() {
+    let block = super::Block::new("Den", "Nis", 228, String::new());
+    if let Ok(b) = serde_json::to_string_pretty(&block) {
+        println!("{}", b)
+    };
+}
+
+#[test]
+fn test_block_deserialize() {
+    let s = r#"{
+        "from": "Den",
+        "to": "Nis",
+        "sum": 228,
+        "hash": ""
+      }"#;
+
+    if let Ok(block) = serde_json::from_slice::<'_, super::Block>(s.as_bytes()) {
+        assert_eq!(block.from, "Den");
+        assert_eq!(block.to, "Nis");
+        assert_eq!(block.sum, 228);
+        assert_eq!(block.hash, "");
+        println!("{:?}", block);
+    }
+}
+
+#[test]
+fn test_new_hash() {
+    let s = super::new_hash("message");
+    assert_eq!(
+        s,
+        "ab530a13e45914982b79f9b7e3fba994cfd1f3fb22f71cea1afbf02b460c6d1d"
+    );
+}


### PR DESCRIPTION
- Move tests to their own file, conditionally compiled
- Make some functions take more flexible arguments instead of String
- Use `serde_json` functions directly instead of intrinsic `serialize`
  and `deserialize`
- Build block file paths as `PathBuf` instead of `String` and
  preallocate the required amount of memory.